### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
 notifications:
   email:
     - coloradocolby@gmail.com
+arch:
+    - amd64
+    - ppc64le


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.